### PR TITLE
fixed win out-of-tree build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -126,7 +126,7 @@ fs_uae_SOURCES = \
 if WINDOWS
 nodist_fs_uae_SOURCES += src/fs-uae/fs-uae.rc
 .rc.o:
-	windres $< -o $@
+	windres $< -o $@ -I$(s)
 endif
 
 fs_uae_LDADD =

--- a/Makefile.am
+++ b/Makefile.am
@@ -1326,3 +1326,6 @@ uninstall-local:
 clean-local:
 	rm -f fs-uae.dat
 	find share -name fs-uae.mo -delete
+
+fs-uae-dist:
+	$(MAKE) -C dist/@OS_NAME@

--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,7 @@ AC_CHECK_LIB([Ws2_32], [main])
 
 AC_SUBST([OS_CPPFLAGS])
 AC_SUBST([OS_LDFLAGS])
+AC_SUBST([OS_NAME])
 AS_CASE([$host_os],
 [mingw*], [
 	OS_NAME="windows"

--- a/dist/macosx/Makefile.in
+++ b/dist/macosx/Makefile.in
@@ -29,4 +29,4 @@ bundle:
 	cp @srcdir@/../../COPYING fs-uae_$(version)_macosx/FS-UAE.app/Contents/Resources/
 	cp @srcdir@/../../README fs-uae_$(version)_macosx/FS-UAE.app/Contents/Resources/
 	@srcdir@/standalone.py fs-uae_$(version)_macosx/FS-UAE.app
-	python3 sign.py fs-uae_$(version)_macosx/FS-UAE.app
+	python3 @srcdir@/sign.py fs-uae_$(version)_macosx/FS-UAE.app

--- a/src/fs-uae/fs-uae.rc.in
+++ b/src/fs-uae/fs-uae.rc.in
@@ -21,4 +21,4 @@ BEGIN
     VALUE "Translation", 0x409, 1252
   END
 END
-2 ICON "@top_srcdir@/icon/fs-uae.ico"
+2 ICON "icon/fs-uae.ico"


### PR DESCRIPTION
Hi Frode,

windows build fails if @top_srcdir@ is an absolute path. The path is in mingw/unix style but windres always needs a native windows path.
This fix works around this problem by using only relative path inside the .rc file and by specifying the source path as an include path. Then the absolute path is still given in mingw notation but now the command line transformation ensures windres receives a native windows path.

Best,
Chris