### PR TITLE
fixed broken non-blocking socket I/O support by using 'sd' correctly.

### DIFF
--- a/src/od-fs/bsdsocket_posix.cpp
+++ b/src/od-fs/bsdsocket_posix.cpp
@@ -1623,20 +1623,14 @@ uae_u32 host_IoctlSocket (TrapContext *context, SB, uae_u32 sd, uae_u32 request,
 #   endif
 
     case 0x8004667E: /* FIONBIO */
-        if (sd == 0) {
-            printf("WARNING: sd was 0 ???\n");
-            sb->resultval = -1;
-            bsdsocklib_seterrno (sb, 9); /* EBADF */
-            return -1;
-        }
         r = fcntl (sock, F_SETFL, argval ?
                flags | O_NONBLOCK : flags & ~O_NONBLOCK);
         if (argval) {
             DEBUG_LOG ("nonblocking\n");
-            sb->ftable[sd-1] &= ~SF_BLOCKING;
+            sb->ftable[sd] &= ~SF_BLOCKING;
         } else {
             DEBUG_LOG ("blocking\n");
-            sb->ftable[sd-1] |= SF_BLOCKING;
+            sb->ftable[sd] |= SF_BLOCKING;
         }
         return r;
 


### PR DESCRIPTION
This pull request refers to issue https://github.com/FrodeSolheim/fs-uae/issues/80 which caused that non-blocking socket I/O was not working for unix/posix versions of FS-UAE. This in fact caused that e.g. YAM wasn't working properly but complained when initializing socket connections. The corresponding function was using the "sd" parameter incorrectly and assumed that sd should never be zero, but which is perfectly valid if -1 decrement is removed when setting the blocking mode to the socket descriptor.