### PR TITLE
Mention the 'autofire_button' key binding action.

### DIFF
--- a/doc/options/joystick_port_0_autofire
+++ b/doc/options/joystick_port_0_autofire
@@ -4,4 +4,11 @@ Since: 2.1.0
 
 Set to enable to enable autofire for this joystick port.
 
+Enabling autofire for a joystick port means that the ordinary fire
+button will give the effect of many rapid-fire short presses. If you
+need to generate a combination of long and rapid-fire presses of the
+fire button, then instead of enabling this setting, you can instead
+configure a different keystroke or controller button to map to
+‘action_joy_0_autofire_button’.
+
 See also [joystick_port_0].


### PR DESCRIPTION
Some games assign different meanings (e.g. different weapons) to short
and long presses of the same fire button. For such a game it is
helpful to be able to generate both a long press of Fire and many
rapid-fire short presses, without having to pause the emulator and
toggle autofire on and off constantly.

Eventually I found out that I could achieve this by binding an extra
key (I used Right Shift, keeping Right Control for long presses of
fire) to the useful value "action_joy_1_autofire_button". But that
value wasn't mentioned in the docs anywhere at all, and I had to read
the source code to find it. It's very useful, so I think it _should_
be documented!