### PR TITLE
Split log and debugger messages into stdout and stderr

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,14 @@
+# To build and publish image run following commands:
+# > docker build -t cahirwpz/demoscene-fs-uae-buildenv:latest .
+# > docker login
+# > docker push cahirwpz/demoscene-fs-uae-buildenv:latest
+
+FROM debian:stretch
+
+WORKDIR /root
+
+RUN apt-get -q update && apt-get upgrade -y
+RUN apt-get install -y --no-install-recommends \
+            ca-certificates zip \
+            git make patch gcc g++ automake libtool gettext pkg-config \
+            libc6-dev libglib2.0-dev libpng-dev libsdl2-dev libopenal-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - run: './bootstrap'
-      - run: './configure --without-libmpeg2 --prefix=/usr/local'
+      - run: './configure-demoscene.sh --prefix=/usr/local'
       - run: 'make'
       - run: 'make install && tar cvzf /demoscene-fs-uae.tar.gz /usr/local'
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+
+defaults: &defaults
+  working_directory: ~/demoscene-fs-uae
+  docker:
+    - image: cahirwpz/demoscene-fs-uae-buildenv:latest
+
+jobs:
+  fs-uae:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: './bootstrap'
+      - run: './configure --without-libmpeg2 --prefix=/usr/local'
+      - run: 'make'
+      - run: 'make install && tar cvzf /demoscene-fs-uae.tar.gz /usr/local'
+      - store_artifacts:
+          path: /demoscene-fs-uae.tar.gz
+
+workflows:
+  version: 2
+  demoscene-fs-uae:
+    jobs:
+      - fs-uae

--- a/configure-demoscene.sh
+++ b/configure-demoscene.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ `uname` = "Darwin" ]; then
+  export CC="clang" CXX="clang++"
+fi
+
+./configure \
+  --without-libmpeg2 \
+  --enable-debugger \
+  --disable-jit \
+  --disable-prowizard \
+  --enable-segtracker \
+  $@

--- a/libfsemu/src/emu/emu.c
+++ b/libfsemu/src/emu/emu.c
@@ -309,10 +309,6 @@ void fse_init_early(void)
 
     fs_init_time();
 
-    if (fs_config_true(OPTION_STDOUT)) {
-        fs_log_enable_stdout();
-    }
-
     fs_log("[FSE] Calling fs_ml_init\n");
     fs_ml_init();
 
@@ -331,6 +327,10 @@ void fse_init(int options)
     fse_init_early();
     fs_log("[FSE] Init\n");
     read_config();
+
+    if (fs_config_true(OPTION_STDOUT)) {
+        fs_log_enable_stdout();
+    }
 
 #ifdef USE_SDL
     fse_log("[FSE] Initializing SDL\n");

--- a/src/fs-uae/main.c
+++ b/src/fs-uae/main.c
@@ -728,16 +728,7 @@ static void log_to_libfsemu(const char *message)
 {
     /* UAE logs some messages char-for-char, so we need to buffer logging
      * here if we want to log with [UAE] prefix. */
-    // fs_log("[UAE] %s", message);
-    static bool initialized;
-    static bool ignore;
-    if (!initialized) {
-        initialized = true;
-        ignore = fs_config_false(OPTION_UAELOG);
-    }
-    if (!ignore) {
-        fs_log_string(message);
-    }
+    fs_log("[UAE] %s", message);
 }
 
 static void main_function()

--- a/src/fs-uae/options.h
+++ b/src/fs-uae/options.h
@@ -46,7 +46,6 @@
 #define OPTION_SOUND_CARD "sound_card"
 #define OPTION_STEREO_SEPARATION "stereo_separation"
 #define OPTION_THEME_ZOOM "theme_zoom"
-#define OPTION_UAELOG "uaelog"
 #define OPTION_UAENATIVE_LIBRARY "uaenative_library"
 #define OPTION_WARP_MODE "warp_mode"
 #define OPTION_WORKBENCH_DISK "workbench_disk"

--- a/src/od-fs/uaemisc.cpp
+++ b/src/od-fs/uaemisc.cpp
@@ -9,6 +9,7 @@
 #include "uae.h"
 #include "xwin.h"
 #include "uae/fs.h"
+#include <fs/conf.h>
 #include "../od-win32/debug_win32.h"
 
 #ifndef PICASSO96
@@ -229,7 +230,6 @@ TCHAR *target_expand_environment (const TCHAR *path) {
     return strdup(path);
 }
 
-#if 0
 #include <signal.h>
 #include "debug.h"
 #ifdef __cplusplus_disabled
@@ -246,11 +246,12 @@ static RETSIGTYPE sigbrkhandler (int foo)
     signal (SIGINT, sigbrkhandler);
 #endif
 }
-#endif
 
 void setup_brkhandler (void)
 {
-    /*
+    if (fs_config_false("console_debugger"))
+        return;
+
 #if defined(__unix) && !defined(__NeXT__)
     struct sigaction sa;
     sa.sa_handler = sigbrkhandler;
@@ -263,7 +264,6 @@ void setup_brkhandler (void)
 #else
     signal (SIGINT, sigbrkhandler);
 #endif
-    */
 }
 
 void sleep_cpu_wakeup(void)

--- a/src/od-fs/uaemisc.cpp
+++ b/src/od-fs/uaemisc.cpp
@@ -84,7 +84,7 @@ void sleep_millis (int ms) {
 void console_out_f(const TCHAR *fmt, ...) {
     va_list arg_ptr;
     va_start(arg_ptr, fmt);
-    vprintf(fmt, arg_ptr);
+    vfprintf(stderr, fmt, arg_ptr);
     va_end(arg_ptr);
 }
 
@@ -101,7 +101,7 @@ void f_out(void *f, const TCHAR *format, ...)
 }
 
 void console_out (const TCHAR *msg) {
-    printf("%s", msg);
+    fprintf(stderr, "%s", msg);
 }
 
 int console_get_gui (TCHAR *out, int maxlen) {
@@ -119,7 +119,7 @@ int console_get(TCHAR *in, int maxlen) {
 }
 
 void console_flush(void) {
-    fflush(stdout);
+    fflush(stderr);
 }
 
 TCHAR console_getch (void) {


### PR DESCRIPTION
This change proposes some minor fixes that enable my `RunInUAE` developer dashboard to hook up into FS-UAE. PR is split into small changes – each one easy to review. Some of the commits probably need extra explanation:

> Remove a kludge that prevents all logs from being recorded.

For unknown reason there was "uaelog" configuration option that was interfering with output of all log messages. I badly need some messages (related to serial & parallel port, TCP connections) to enable my wrapper to detect when a listening port was opened.

> Use stderr for console debugger output.

This makes my life much easier because logs and debugger messages are split into two pipes. My dashboard is simpler because I don't have to classify messages incoming on stdout into two groups.

> Enter debugger on CTRL+C if console debugger is enabled.

The change makes debugging exprience better as I can break my code at any point while observing log messages incoming on parallel port (happens to be channel for sending log messages from Amiga program). I did not expect this code to be commented out. Sure there's only sense to activate it when "console_debugger" option is set to 1.

Perhaps this functionality should be enabled by extra configuration option... what do you think?
