### PR TITLE
Create more reproducible .zip files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1410,8 +1410,9 @@ mo: $(catalogs)
 
 fs-uae.dat: $(catalogs)
 	rm -f fs-uae.dat
-	cd $(s) && $(ZIP) -r $(abs_builddir)/fs-uae.dat share
-	cd $(b) && $(ZIP) -r $(abs_builddir)/fs-uae.dat share
+	for d in $(s) $(b) ; do \
+	  ( cd $$d && $(ZIP) -X $(abs_builddir)/fs-uae.dat $$(find share | LC_ALL=C sort ) ) ; \
+	done
 
 all-local: mo fs-uae.dat
 


### PR DESCRIPTION
While working on reproducible builds for openSUSE, I found that
the fs-uae.dat in our package varied for every build.

Therefore I propose this patch to
Create more reproducible .zip files
avoid indeterministic filesystem order
and use -X to omit extended attributes from zip file
to help make fs-uae package build reproducible

See https://reproducible-builds.org/ for why this is good.


One remaining issue is with mtimes that also get embedded into the zip.

`touch -d@$CONSTANT` can help there (but only with GNU touch).

or `touch -r $REFERENCEFILE` (works with GNU touch and BSD touch)

or we post-process it in our package build process with `strip-nondeterminism -t zip`