### PR TITLE
Only run configure in libmpeg2 when using built-in version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 # Makefile.am for FS-UAE
 
 SUBDIRS =
+DIST_SUBDIRS =
 
 WARNINGS =
 
@@ -1262,6 +1263,7 @@ endif
 
 if BUILTIN_LIBMPEG2
 SUBDIRS += libmpeg2
+DIST_SUBDIRS += libmpeg2
 AM_CPPFLAGS += -I$(s)/libmpeg2/include
 fs_uae_LDADD += \
 	libmpeg2/libmpeg2/.libs/libmpeg2.a \
@@ -1276,6 +1278,7 @@ SUBDIRS += libnfd
 AM_CPPFLAGS += -I$(s)/libnfd/src/include
 fs_uae_LDADD += libnfd.a
 endif
+DIST_SUBDIRS += libnfd
 
 
 noinst_LIBRARIES += libdummy.a

--- a/configure.ac
+++ b/configure.ac
@@ -801,7 +801,9 @@ OPT_FEATURE([A_ZIP], [zip], [zip],
 
 AC_DEFINE([FPU_UAE], [1], [Define to 1])
 
-AC_CONFIG_SUBDIRS([libmpeg2])
+AS_IF([test "x$with_libmpeg2" = xbuiltin], [
+    AC_CONFIG_SUBDIRS([libmpeg2])
+])
 
 # Write Makefile
 


### PR DESCRIPTION
A similar patch was submitted to Gentoo but that one made configure fall back to the built-in version if the system version was requested but not found. I believe the existing behaviour of failing with an error makes more sense.

I also have a patch to use the system Udis86 but I noticed that Udis86 is not used at all since the `USE_UDIS86` macro was commented out a few years ago. I could send the pull request anyway but I don't know whether it will be reintroduced?