### PR TITLE
Define unknown host CPUs as CPU_unknown

### DIFF
--- a/src/include/sysdeps.h
+++ b/src/include/sysdeps.h
@@ -50,7 +50,7 @@ using namespace std;
 #elif defined(__powerpc__) || defined(__ppc__) || defined(_M_PPC)
 #define CPU_powerpc 1
 #else
-#error unrecognized CPU type
+#define CPU_unknown 1
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
This allows fs-uae to be built on any CPU architecture.

This patch is currently part of the fs-uae package shipped in Debian.