### PR TITLE
Menu auto pause

### DIFF
--- a/README
+++ b/README
@@ -88,6 +88,10 @@ While running the emulator, you press F12 to enter and exit the emulator menu.
 From here, you can load and save states, and swap floppy disks. On macOS,
 you can use Cmd+F12 instead (Or Fn+Cmd+F12).
 
+By default the emulator will pause when you enter the menu and resume when you
+exit the menu. If you would like the emulator to continue running whilst you
+are in the menu then you should add the option `menu_dont_auto_pause = 1`
+
 With gamepads, you enter the menu either by using the dedicated "menu" button,
 if the gamepad has one, or you press and hold "start" and "selected" at the
 same time (or equivalent buttons). Use the same key/button to close the menu.

--- a/docs/options/menu_dont_auto_pause
+++ b/docs/options/menu_dont_auto_pause
@@ -1,0 +1,6 @@
+Default: 0
+Example: 1
+
+If set to 1 then emulation will continue to run even after the menu button
+has been pressed. If set to 0 (default) then emulation will be paused until
+either the menu is dismissed or "resume" is selected.

--- a/libfsemu/src/emu/menu.c
+++ b/libfsemu/src/emu/menu.c
@@ -735,7 +735,6 @@ static void enter_menu(void)
         go_back_in_menu_stack();
     }
 
-    //fs_emu_pause(1);
     g_fs_emu_menu_mode = 1;
     if (g_menu) {
         if (g_menu->update) {
@@ -744,6 +743,10 @@ static void enter_menu(void)
     }
     did_have_input_grab_before_menu = fs_emu_input_grab();
     fs_emu_set_input_grab_and_visibility(false, 0);
+    
+    // Automatically pause emulation
+	if (fs_config_get_boolean("menu_dont_auto_pause") != 1)
+		fs_emu_pause(1);
 }
 
 static void leave_menu(void)
@@ -751,6 +754,10 @@ static void leave_menu(void)
     fs_emu_log("EMU: Leave menu\n");
     g_fs_emu_menu_mode = 0;
     fs_emu_set_input_grab(did_have_input_grab_before_menu);
+    
+    // Automatically unpause emulation
+	if (fs_config_get_boolean("menu_dont_auto_pause") != 1)
+		fs_emu_pause(-1);
 }
 
 bool fs_emu_menu_mode(void)


### PR DESCRIPTION
Resolves FrodeSolheim/fs-uae#4

- Automatically pauses emulation when the menu is displayed. This replicates standard behavior in all other emulators and will be less confusing for users.
- Enables an option `menu_dont_auto_pause` for people who prefer to disable this functionality.
- Adds documentation to explain the setting.

