### PR TITLE
Make build work on apple sillicon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -397,7 +397,7 @@ AS_CASE([$host_os],
     OS_NAME_3="macOS"
     OS_CPPFLAGS="-DMACOSX -DMACOS"
     LOADABLE_MODULE_EXT=".so"
-    OS_LDFLAGS="-headerpad_max_install_names -pagezero_size 0x2000 -rpath @executable_path/../Frameworks"
+    OS_LDFLAGS="-headerpad_max_install_names -rpath @executable_path/../Frameworks"
 ],
 [freebsd*], [
     OS_NAME="freebsd"

--- a/libfsemu/src/emu/actions.c
+++ b/libfsemu/src/emu/actions.c
@@ -26,6 +26,7 @@
 #include <fs/emu/actions.h>
 #include <fs/emu/input.h>
 #include <fs/emu/video.h>
+#include <fs/emu/render.h>
 #include <fs/lazyness.h>
 #include <fs/glib.h>
 #include "video.h"


### PR DESCRIPTION
This makes fs-uae build on Apple Silicon / M1 Macs. The generated executable seems to run. Have not tested it in detail.