### PR TITLE
Option to enable automatic pausing when in the menu

### DIFF
--- a/README
+++ b/README
@@ -95,6 +95,11 @@ With gamepads, you enter the menu either by using the dedicated "menu" button,
 if the gamepad has one, or you press and hold "start" and "selected" at the
 same time (or equivalent buttons). Use the same key/button to close the menu.
 
+By default, the emulator will continue to run whilst the menu is being displayed.
+If you would like to change this so that it's automatically paused when you enter
+the menu and resumes when you exit then you should add the option
+`menu_auto_pause = 1`.
+
 In the menu, you use the following keys for navigation:
 
 - Cursor keys

--- a/docs/options/menu_auto_pause
+++ b/docs/options/menu_auto_pause
@@ -1,0 +1,6 @@
+Default: 0
+Example: 1
+
+If set to 0 (default) then emulation will continue to run even after the
+menu button has been pressed. If set to 1 then emulation will be paused
+until either the menu is dismissed or "resume" is selected.

--- a/libfsemu/src/emu/emu.c
+++ b/libfsemu/src/emu/emu.c
@@ -239,6 +239,7 @@ void fs_emu_pause(int pause)
     //fs_emu_grab_input(g_pause_mode == 1);
     g_pause_mode = pause;
     g_pause_function(pause);
+	g_fs_emu_resume_on_menu_exit = 0;  // Don't resume emulation
 }
 
 int fs_emu_is_paused()

--- a/libfsemu/src/emu/libfsemu.h
+++ b/libfsemu/src/emu/libfsemu.h
@@ -63,5 +63,5 @@ extern int g_fs_emu_scanlines_dark;
 extern int g_fs_emu_scanlines_light;
 
 extern fs_emu_texture *g_fs_emu_overlay_texture;
-
+extern int g_fs_emu_resume_on_menu_exit;
 #endif

--- a/libfsemu/src/emu/menu.c
+++ b/libfsemu/src/emu/menu.c
@@ -737,7 +737,10 @@ static void enter_menu(void)
         go_back_in_menu_stack();
     }
 
-    //fs_emu_pause(1);
+    // Automatically pause emulation
+    if (fs_config_get_boolean("menu_auto_pause") == 1)
+        fs_emu_pause(1);
+
     g_fs_emu_menu_mode = 1;
     if (g_menu) {
         if (g_menu->update) {
@@ -753,6 +756,10 @@ static void leave_menu(void)
     fs_emu_log("EMU: Leave menu\n");
     g_fs_emu_menu_mode = 0;
     fs_emu_set_input_grab(did_have_input_grab_before_menu);
+	
+    // Automatically unpause emulation
+    if (fs_config_get_boolean("menu_auto_pause") == 1)
+        fs_emu_pause(-1);
 }
 
 bool fs_emu_menu_mode(void)

--- a/libfsemu/src/emu/menu.c
+++ b/libfsemu/src/emu/menu.c
@@ -37,6 +37,7 @@ static int g_top_menu_focus = 0;
 int g_fs_emu_menu_mode = 0;
 
 static int g_update_current_menu = 0;
+int g_fs_emu_resume_on_menu_exit = 0;
 
 void fs_emu_menu_update_current()
 {
@@ -737,9 +738,12 @@ static void enter_menu(void)
         go_back_in_menu_stack();
     }
 
-    // Automatically pause emulation
-    if (fs_config_get_boolean("menu_auto_pause") == 1)
+    // Automatically pause emulation if not already paused and configured
+    if (!fs_emu_is_paused() && fs_config_get_boolean("menu_auto_pause") == 1)
+	{
         fs_emu_pause(1);
+		g_fs_emu_resume_on_menu_exit = 1;  // Force resume on exit
+	}
 
     g_fs_emu_menu_mode = 1;
     if (g_menu) {
@@ -757,9 +761,10 @@ static void leave_menu(void)
     g_fs_emu_menu_mode = 0;
     fs_emu_set_input_grab(did_have_input_grab_before_menu);
 	
-    // Automatically unpause emulation
-    if (fs_config_get_boolean("menu_auto_pause") == 1)
-        fs_emu_pause(-1);
+    // Automatically unpause emulation - but only if it was automatically
+	// paused when we first entered the menu (and hasn't changed since)	
+    if (g_fs_emu_resume_on_menu_exit == 1 && fs_emu_is_paused() && fs_config_get_boolean("menu_auto_pause") == 1)
+        fs_emu_pause(0);
 }
 
 bool fs_emu_menu_mode(void)


### PR DESCRIPTION
Second attempt to resolve FrodeSolheim/fs-uae#4 after I accidentally mangled my fork the first time around 🙄 

- Added an option `menu_auto_pause` which (when enabled) automatically pauses emulation when the menu is displayed.
- By default is off, maintaining existing user experience
- Updated documentation to detail the setting