### PR TITLE
Fix regression with "virtual RDBs"

### DIFF
--- a/src/od-fs/hardfile_host.cpp
+++ b/src/od-fs/hardfile_host.cpp
@@ -576,14 +576,6 @@ int hdf_read_target (struct hardfiledata *hfd, void *buffer, uae_u64 offset, int
 
     if (hfd->drive_empty)
         return 0;
-    if (offset < hfd->virtual_size) {
-        uae_u64 len2 = offset + len <= hfd->virtual_size ? len : hfd->virtual_size - offset;
-        if (!hfd->virtual_rdb)
-            return 0;
-        memcpy (buffer, hfd->virtual_rdb + offset, len2);
-        return len2;
-    }
-    offset -= hfd->virtual_size;
     while (len > 0) {
         int maxlen;
         int ret = 0;
@@ -674,13 +666,6 @@ int hdf_write_target (struct hardfiledata *hfd, void *buffer, uae_u64 offset, in
         }
         return 0;
     }
-    if (offset < hfd->virtual_size) {
-        if (g_debug) {
-            write_log("offset < hfd->virtual_size\n");
-        }
-        return len;
-    }
-    offset -= hfd->virtual_size;
     while (len > 0) {
         int maxlen = len > CACHE_SIZE ? CACHE_SIZE : len;
         int ret = hdf_write_2 (hfd, p, offset, maxlen);


### PR DESCRIPTION
Commit 16e10332036d2d7474bbb6beb94a9310be4aebfd introduced a regression when handling read/write of "virtual RDBs".
Currently the `offset < hfd->virtual_size` check is done both in `hardfile.cpp` ([here](https://github.com/FrodeSolheim/fs-uae/blob/master/src/hardfile.cpp#L1070-L1082)) and in `hardfile_host.cpp` ([here](https://github.com/FrodeSolheim/fs-uae/blob/master/src/od-fs/hardfile_host.cpp#L579-L585)).
This change removes the latter.

The regression can be observed by attaching a .hdf (that is missing the RDB), while using the `hard_drive_0_controller=ide` config. Without this fix FS-UAE will show a "Not a DOS disk" requester.