### PR TITLE
Fix for uaenative option working

### DIFF
--- a/src/fsuae/fsuae-config.c
+++ b/src/fsuae/fsuae-config.c
@@ -318,7 +318,7 @@ void fs_uae_configure_amiga_hardware()
     }
 
     if (fs_config_get_boolean(OPTION_UAENATIVE_LIBRARY) == 1) {
-        amiga_set_option("bsdsocket_emu", "yes");
+        amiga_set_option("native_code", "yes");
     }
 
     if (fs_config_get_boolean(OPTION_LINE_DOUBLING) == 0) {


### PR DESCRIPTION
This is a small PR to fix the uaenative option (It still requires some other rom-enabling option to be present) but now at least sets the correct option. Looks like there were earlier some copy/paste error in the code