### PR TITLE
Don't return NULL in mapped_malloc when a bool is expected

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1872,7 +1872,7 @@ bool mapped_malloc (addrbank *ab)
 	if (id == -1) {
 		nocanbang ();
 		if (recurse)
-			return NULL;
+			return false;
 		recurse++;
 		mapped_malloc (ab);
 		recurse--;
@@ -1904,7 +1904,7 @@ bool mapped_malloc (addrbank *ab)
 		return ab->baseaddr != NULL;
 	}
 	if (recurse)
-		return NULL;
+		return false;
 	nocanbang ();
 	recurse++;
 	mapped_malloc (ab);


### PR DESCRIPTION
This was apparently breaking the build under musl.

There may be other musl issues (I don't use it personally) but this was just wrong in any case.