### PR TITLE
Point out that pkgconf is needed for bootstrap too (Ubuntu).

### DIFF
--- a/docs/compiling.md
+++ b/docs/compiling.md
@@ -19,7 +19,7 @@ Supported options:
 
 Install dependencies for running bootstrap:
 
-    sudo apt-get install autoconf automake libtool gettext
+    sudo apt-get install autoconf automake libtool gettext pkgconf
 
 Run bootstrap (only when building from git repo):
 


### PR DESCRIPTION
For bootstrap to work on Ubuntu 24, pkgconf also needs to be installed.
