### PR TITLE
Update blkdev_cdimage.cpp

### DIFF
--- a/blkdev_cdimage.cpp
+++ b/blkdev_cdimage.cpp
@@ -818,9 +818,15 @@ static int command_play (int unitnum, int startlsn, int endlsn, int scan, play_s
 	cdu->cdda_subfunc = subfunc;
 	cdu->cdda_statusfunc = statusfunc;
 	cdu->cdda_scan = scan > 0 ? 10 : (scan < 0 ? 10 : 0);
-	cdu->cdda_delay = setstate (cdu, -1, -1);
-	cdu->cdda_delay_frames = setstate (cdu, -2, -1);
-	setstate (cdu, cdu->cdda_delay > 0 || cdu->cdda_delay_frames ? AUDIO_STATUS_NOT_SUPPORTED : AUDIO_STATUS_IN_PROGRESS, -1);
+	if (currprefs.deterministic) {
+    	cdu->cdda_delay = 0;
+    	cdu->cdda_delay_frames = 0;
+    	setstate (cdu, AUDIO_STATUS_IN_PROGRESS, -1);
+	} else {
+    	cdu->cdda_delay = setstate (cdu, -1, -1);
+    	cdu->cdda_delay_frames = setstate (cdu, -2, -1);
+    	setstate (cdu, cdu->cdda_delay > 0 || cdu->cdda_delay_frames ? AUDIO_STATUS_NOT_SUPPORTED : AUDIO_STATUS_IN_PROGRESS, -1);
+	}
 	if (!isaudiotrack (&cdu->di.toc, startlsn)) {
 		setstate (cdu, AUDIO_STATUS_PLAY_ERROR, -1);
 		return 0;


### PR DESCRIPTION
Possible Fix CD for audio track change desync in netplay (deterministic mode)

Problem
CD-based games using CD audio tracks cause netplay desync exactly at track change events. The desync occurs consistently at track starts — if no track change happens the session remains stable indefinitely. This is a known issue documented at https://fs-uae.net/known-issues/:  "CD-based games with CD audio may cause synchronization issues with the emulator. It is not tested, but it is a likely problem."

Root Cause
In command_play() in blkdev_cdimage.cpp, the seek delay is set from variable host timing:




After further testing the partial fix (zeroing cdda_delay and cdda_delay_frames in deterministic mode) does not fully resolve the desync. Binary testing confirmed the values are correctly zeroed but desyncs still occur at track changes.
Deeper analysis suggests the root cause is higher up the stack. The CD status callback (cdda_statusfunc) fires from the audio thread asynchronously and writes to Amiga memory at different emulation frame counts on each client. Since the netplay checksum covers chip/slow/fast RAM, when the game polls CD status and writes the result to memory at different frames on each client, the checksums diverge and desync is detected.
The complete fix likely requires CD play events to be routed through the netplay synchronization server the same way floppy swap events already are — both clients need to apply the track change on the same emulation frame rather than independently from their own audio threads.
The current patch is still worth keeping as it removes one source of timing variance, but the full fix needs the netplay layer in od-fs to synchronize CD play/stop/track change events similarly to how disk_swap events are handled.
References:

Floppy swap sync as the model to follow
blkdev_cdimage.cpp command_play() as the entry point
cdda_statusfunc callback as where Amiga memory gets written